### PR TITLE
minor fix: Fix invalid pointer exception

### DIFF
--- a/src/openboardview/unix.cpp
+++ b/src/openboardview/unix.cpp
@@ -30,7 +30,7 @@ char *file_as_buffer(size_t *buffer_size, const char *utf8_filename) {
 }
 
 char *show_file_picker() {
-	char *path;
+	char *path = nullptr;
 	GtkWidget *parent, *dialog;
 
 	if (!gtk_init_check(NULL, NULL))


### PR DESCRIPTION
If the user canceled the open dialogue an undefined `path` was
returned from `show_file_picker` leading to an invalid pointer
exception when `BoardView::Update` tried to `free()` the returned
`path`

------------------------------------

#### Steps to Reproduce:

* Open openboardviewer (build from linux-support)
* Open the "open" dialogue
* Cancel the "open" dialogue
    * Note error:
```
Error opening �]�UH��H��P�!���H�E�H�E��@|��t
�: No such file or directory
```
* Either exit or try to open a file
    * Note crash:
```
*** Error in `./bin/openboardview': free(): invalid pointer: 0x00007f4da3f809df ***
======= Backtrace: =========
/lib64/libc.so.6(+0x77d75)[0x7f4da06f0d75]
/lib64/libc.so.6(+0x801ca)[0x7f4da06f91ca]
/lib64/libc.so.6(cfree+0x4c)[0x7f4da06fc72c]
./bin/openboardview(_ZN9BoardViewD1Ev+0x48)[0x41caaa]
./bin/openboardview(main+0x301)[0x42e921]
/lib64/libc.so.6(__libc_start_main+0xf0)[0x7f4da0699580]
./bin/openboardview(_start+0x29)[0x41bb19]
```